### PR TITLE
Add calculate output dimension of the ResNet

### DIFF
--- a/next_sparseconvnet/networks/architectures.py
+++ b/next_sparseconvnet/networks/architectures.py
@@ -63,7 +63,7 @@ class UNet(torch.nn.Module):
                 Number of planes that enter the UNet. The default is 1.
         '''
 
-        bottom_spatial_size = calculate_ouput_dimension(spatial_size, kernel_sizes, stride_sizes)
+        bottom_spatial_size = calculate_output_dimension(spatial_size, kernel_sizes, stride_sizes)
 
         torch.nn.Module.__init__(self)
 

--- a/next_sparseconvnet/networks/architectures.py
+++ b/next_sparseconvnet/networks/architectures.py
@@ -14,14 +14,15 @@ class UNet(torch.nn.Module):
         ----------
         spatial_size : tuple
             The spatial size of the input layer. Size of the tuple is also the dimension.
-        inplanes : int
+        init_conv_nplaness : int
             Number of planes we want after the initial SubmanifoldConvolution, that is, to begin downsampling.
-        kernel : list
-            Size of the kernels applied in each layer or block. Its length also indicates the level depth of the UNet.
-        stride : int
-            Applied stride in every layer or block.
-        conv_kernel : int
+        init_conv_kernel : int
             Kernel for the first convolutional layer.
+        kernel_sizes : list
+            Sizes of the kernels applied in each layer or block. Its length also indicates the level depth of the UNet.
+            Last element corresponds just to the kernel of the basic block in the bottom of the UNet.
+        stride_sizes : list
+            Sizes of the strides applied in each downsample/upsample.
         basic_num : int
             Number of times a basic residual block is passed in each level.
         nclasses : int, optional
@@ -37,7 +38,7 @@ class UNet(torch.nn.Module):
             Passes the input through the UNet
      '''
 
-    def __init__(self, spatial_size, init_conv_nplanes, init_conv_kernel, kernel_sizes, stride, basic_num, nclasses = 3, dim = 3, start_planes = 1):
+    def __init__(self, spatial_size, init_conv_nplanes, init_conv_kernel, kernel_sizes, stride_sizes, basic_num, nclasses = 3, dim = 3, start_planes = 1):
         '''
             Parameters
             ----------
@@ -48,10 +49,10 @@ class UNet(torch.nn.Module):
             init_conv_kernel : int
                 Kernel for the first convolutional layer.
             kernel_sizes : list
-                Size of the kernels applied in each layer or block. Its length also indicates the level depth of the UNet.
+                Sizes of the kernels applied in each layer or block. Its length also indicates the level depth of the UNet.
                 Last element corresponds just to the kernel of the basic block in the bottom of the UNet.
-            stride : int
-                Applied stride in every layer or block.
+            stride_sizes : list
+                Sizes of the strides applied in each downsample/upsample.
             basic_num : int
                 Number of times a basic residual block is passed in each level.
             nclasses : int, optional
@@ -93,8 +94,8 @@ class UNet(torch.nn.Module):
             for j in range(basic_num):
                 self.basic_down[i].append(ResidualBlock_basic(inplanes, kernel_sizes[i])) #basic blocks for downsample branch
                 self.basic_up[i].append(ResidualBlock_basic(inplanes, kernel_sizes[i])) #basic blocks for upsample branch
-            self.downsample.append(ResidualBlock_downsample(inplanes, kernel_sizes[i], stride)) #downsamples
-            self.upsample.append(ResidualBlock_upsample(2 * inplanes, kernel_sizes[i], stride)) #upsamples, backwards
+            self.downsample.append(ResidualBlock_downsample(inplanes, kernel_sizes[i], stride_sizes[i])) #downsamples
+            self.upsample.append(ResidualBlock_upsample(2 * inplanes, kernel_sizes[i], stride_sizes[i])) #upsamples, backwards
 
             inplanes = inplanes * 2
 

--- a/next_sparseconvnet/networks/architectures.py
+++ b/next_sparseconvnet/networks/architectures.py
@@ -1,7 +1,7 @@
 
 import torch
 import sparseconvnet as scn
-from .building_blocks import ResidualBlock_downsample, ResidualBlock_basic, ResidualBlock_upsample, ConvBNBlock
+from .building_blocks import ResidualBlock_downsample, ResidualBlock_basic, ResidualBlock_upsample, ConvBNBlock, calculate_output_dimension
 
 class UNet(torch.nn.Module):
     '''
@@ -63,11 +63,7 @@ class UNet(torch.nn.Module):
                 Number of planes that enter the UNet. The default is 1.
         '''
 
-        #Assure that kernel sizes are suitable for our input size
-        for o in spatial_size:
-            for i, k in enumerate(kernel_sizes[:-1]):
-                o = (o - k)/stride + 1
-                assert o == int(o), 'Shape mismatch: kernel size {} in level {} does not return a suitable size for the output'.format(k, i)
+        bottom_spatial_size = calculate_ouput_dimension(spatial_size, kernel_sizes, stride_sizes)
 
         torch.nn.Module.__init__(self)
 

--- a/next_sparseconvnet/networks/building_blocks.py
+++ b/next_sparseconvnet/networks/building_blocks.py
@@ -100,3 +100,16 @@ class ConvBNBlock(torch.nn.Module):
         x = self.conv(x)
         x = self.bnr(x)
         return x
+
+
+def calculate_output_dimension(spatial_size, kernel_sizes, stride_sizes):
+    """Assures that kernel and stride sizes are suitable for our input size and returns the output size for the bottom layer after downsampling.
+       Note that kernel_sizes' last element does not correspond to the kernel of a downsample, so it does not count for the calculation
+    """
+    out_dim = []
+    for o in spatial_size:
+        for i, k in enumerate(kernel_sizes[:-1]):
+            o = (o - k)/stride_sizes[i] + 1
+            assert o == int(o), 'Shape mismatch: kernel size {} in level {} does not return a suitable size for the output'.format(k, i)
+        out_dim.append(int(o))
+    return out_dim

--- a/next_sparseconvnet/networks/building_blocks_test.py
+++ b/next_sparseconvnet/networks/building_blocks_test.py
@@ -80,3 +80,14 @@ def test_ConvBNBlock(MCdataset):
     for i, size in enumerate(spatial_size):
         assert out.spatial_size[i] == size
     assert out_with_stride.spatial_size[i] == (size - kernel) / stride + 1
+
+
+def test_calculate_ouput_dimension():
+    spatial_size = (561, 561, 561)
+    kernel_sizes = [9, 7, 5, 3, 3]
+    stride_sizes = [4, 2, 2, 2]
+    with pytest.raises(AssertionError):
+        calculate_output_dimension(spatial_size, kernel_sizes, stride_sizes)
+
+    spatial_size = (289, 417, 449)
+    assert calculate_output_dimension(spatial_size, kernel_sizes, stride_sizes) == [7, 11, 12]


### PR DESCRIPTION
Add function calculate_output_dimension to module building_blocks.py. This function guarantees that after downsampling with certain kernels and strides, the output has an integer size.